### PR TITLE
Fix issue: Failed to call /userinfo API after add Admin UI

### DIFF
--- a/authorization-server/src/main/kotlin/com/ntgjvmagent/authorizationserver/config/AuthorizationServerConfig.kt
+++ b/authorization-server/src/main/kotlin/com/ntgjvmagent/authorizationserver/config/AuthorizationServerConfig.kt
@@ -119,7 +119,7 @@ class AuthorizationServerConfig {
             // Extract roles from authorities (remove ROLE_ prefix for cleaner claims)
             val roles = authorities.map { authority ->
                 authority.authority.removePrefix("ROLE_")
-            }.toSet()
+            }
 
             // Add roles to both access tokens and ID tokens
             if (context.tokenType == OAuth2TokenType.ACCESS_TOKEN) {


### PR DESCRIPTION
 Before fix:
 
<img width="1261" height="941" alt="image" src="https://github.com/user-attachments/assets/789e3592-7031-4263-82fd-78b85969346e" />

After fix:

<img width="1251" height="737" alt="image" src="https://github.com/user-attachments/assets/c2618469-8bab-4ead-a180-b35e7f69b0c4" />

 Solution: Removed converting roles to Set, ArrayList is safer and fully compatible with Jackson serialization.