### PR TITLE
feat: application properties for Google Gemini configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ This project aims to practice building a chatbot in Kotlin
 - Choose AI Provider:
   - GitHub Model: Setup [GitHub models](https://docs.github.com/en/github-models/use-github-models/prototyping-with-ai-models) (free): Create your Fine-grained personal access tokens in GitHub https://github.com/settings/personal-access-tokens. The token needs to have **models:read** permissions.
   - Google Gemini: Setup [Gemini API](https://aistudio.google.com/): Create your API key in Google AI Studio https://aistudio.google.com/api-keys
-- Update the application.properties with your GitHub token or Gemini Api key
-- Open terminal of your choice, go to ntg-jvm-agent directory, run docker compose up
+- Enable the base URL of your provider in application.properties
+  - GitHub Models: `spring.ai.openai.base-url=https://models.github.ai/inference`
+  - Google Gemini: `spring.ai.openai.chat.base-url=https://generativelanguage.googleapis.com`
+- Update the application.properties with your GitHub token or Gemini API key.
+- Open terminal of your choice, go to ntg-jvm-agent directory, run docker compose up.
 
 ### Services
 - PgAdmin: http://localhost:3560/ Account login: admin@ntg.com / admin. Register a server: postgres, port 5432, username admin, password admin.

--- a/orchestrator/src/main/resources/application.properties
+++ b/orchestrator/src/main/resources/application.properties
@@ -4,7 +4,7 @@ server.port=9001
 # ==========================================================
 # GitHub Models
 # ==========================================================
-spring.ai.openai.base-url=https://models.github.ai/inference
+#spring.ai.openai.base-url=https://models.github.ai/inference
 spring.ai.openai.api-key=your GitHub token
 spring.ai.openai.embedding.options.model=openai/text-embedding-3-small
 spring.ai.openai.embedding.embeddings-path=/embeddings
@@ -19,10 +19,14 @@ spring.ai.openai.embedding.embeddings-path=/embeddings
 
 #spring.ai.openai.embedding.base-url=https://generativelanguage.googleapis.com
 #spring.ai.openai.embedding.embeddings-path=/v1beta/openai/embeddings
-#spring.ai.openai.embedding.options.model=models/text-embedding-004
+#spring.ai.openai.embedding.options.model=text-embedding-004
+# Note: Update spring.ai.vectorstore.pgvector.embedding-dimension to 768 when using text-embedding-004
 
 spring.ai.vectorstore.pgvector.enabled=true
 spring.ai.vectorstore.pgvector.embedding-dimension=1536
+# WARNING: Set the embedding dimension to match the embedding model in use.
+# For OpenAI text-embedding-3-small, use 1536. For Google text-embedding-004, use 768.
+
 spring.ai.vectorstore.pgvector.datasource.url=jdbc:postgresql://localhost:5432/orchestrator
 spring.ai.vectorstore.pgvector.datasource.username=admin
 spring.ai.vectorstore.pgvector.datasource.password=admin


### PR DESCRIPTION
- Supports switching from GitHub Model to Google Gemini.

<img width="1282" height="856" alt="Screenshot 2025-11-10 112753" src="https://github.com/user-attachments/assets/f6e14c5d-ec41-4b20-903c-f300255310fa" />
<img width="1482" height="765" alt="image" src="https://github.com/user-attachments/assets/77950f64-94dd-4123-81a9-0e67d963cd6f" />
